### PR TITLE
Fix url for docker tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER olga.botvinnik@czbiohub.org
 # Suggested tags from https://microbadger.com/labels
 ARG VCS_REF
 LABEL org.label-schema.vcs-ref=$VCS_REF \
-org.label-schema.vcs-url="e.g. https://github.com/microscaling/microscaling"
+org.label-schema.vcs-url="e.g. https://github.com/czbiohub/nf-kmer-similarity"
 
 
 WORKDIR /home


### PR DESCRIPTION
Forgot to put this in the previous PR ... https://github.com/czbiohub/nf-kmer-similarity/pull/3