### PR TITLE
Use olgabot/dayhoff branch to build sourmash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # nf-core/nf-kmer-similarity: Changelog
 
-## v1.0dev - 6 March 2019
+## v1.1dev
+
+* Add option to use Dayhoff encoding for sourmash
+
+## v1.0 - 6 March 2019
 Initial release of nf-core/nf-kmer-similarity, created with the [nf-core](http://nf-co.re/) template.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,13 +36,14 @@ RUN cd /home && \
 RUN trim-low-abund.py --help
 RUN trim-low-abund.py --version
 
+# RUN conda install --channel bioconda --yes sourmash
 
 # Required for multiprocessing of 10x bam file
 # RUN pip install pathos bamnostic
 
-# ENV SOURMASH_VERSION master
+ENV SOURMASH_VERSION 'olgabot/dayhoff'
 RUN cd /home && \
-    git clone https://github.com/dib-lab/sourmash.git && \
+    git clone --branch $SOURMASH_VERSION https://github.com/czbiohub/sourmash.git && \
     cd sourmash && \
     python3 setup.py install
 


### PR DESCRIPTION
Use this branch: https://github.com/dib-lab/sourmash/pull/689 to build the docker image to add option for Dayhoff encoding. Need to merge this in first so the docker image is auto-built properly

## PR checklist
 - [x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/kmer-similarity branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/kmer-similarity)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [x] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/kmer-similarity/tree/master/.github/CONTRIBUTING.md
